### PR TITLE
Update futures-lite deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 
 [dependencies]
 tokio = { version = "1.0", features = ["net"] }
-futures-lite = "1.11"
+futures-lite = "2.5"
 libc = "0.2"
 
 [dev-dependencies]


### PR DESCRIPTION
Fixing https://github.com/polachok/tokio-eventfd/issues/3

Update futures-lite deps which in turn avoids pulling unmaintained `instant` crate.

Ref:
https://rustsec.org/advisories/RUSTSEC-2024-0384

Cargo deny error:

```
117 │ instant 0.1.13 registry+https://github.com/rust-lang/crates.io-index
    │ -------------------------------------------------------------------- unmaintained advisory detected
    │
    = ID: RUSTSEC-2024-0384
    = Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0384
    = This crate is no longer maintained, and the author recommends using the maintained [`web-time`] crate instead.

      [`web-time`]: https://crates.io/crates/web-time
    = Solution: No safe upgrade is available!
    = instant v0.1.13
      └── fastrand v1.9.0
          └── futures-lite v1.13.0
              └── tokio-eventfd v0.2.1
```