### PR TITLE
Remove dependency on futures-lite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,7 @@ repository = "https://github.com/polachok/tokio-eventfd"
 license = "MIT"
 
 [dependencies]
-tokio = { version = "1.0", features = ["net"] }
-futures-lite = "2.5"
+tokio = { version = "1.0", features = [] }
 libc = "0.2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ repository = "https://github.com/polachok/tokio-eventfd"
 license = "MIT"
 
 [dependencies]
-tokio = { version = "1.0", features = [] }
+tokio = { version = "1.10.0", features = [] }
 libc = "0.2"
 
 [dev-dependencies]
-tokio = { version = "1.0", features = ["net", "rt", "test-util", "macros", "io-util", "time" ] }
+tokio = { version = "1.10.0", features = ["net", "rt", "test-util", "macros", "io-util", "time" ] }


### PR DESCRIPTION
futures-lite is only used for a convenience macro and it's easy enough to inline it. This avoids pulling in futures-lite dependencies like fastrand and waker-fn, reducing the need for security updates.

Separately, tokio's net feature is not needed, so remove it.

Before:
```
tokio-eventfd v0.2.1 (/home/chadaustin/projects/tokio-eventfd-2)
├── futures-lite v1.13.0
│   ├── fastrand v1.9.0
│   ├── futures-core v0.3.31
│   ├── futures-io v0.3.31
│   ├── memchr v2.7.4
│   ├── parking v2.2.1
│   ├── pin-project-lite v0.2.15
│   └── waker-fn v1.2.0
├── libc v0.2.164
└── tokio v1.41.1
    ├── bytes v1.8.0
    ├── libc v0.2.164
    ├── mio v1.0.2
    │   └── libc v0.2.164
    ├── pin-project-lite v0.2.15
    ├── socket2 v0.5.7
    │   └── libc v0.2.164
    └── tokio-macros v2.4.0 (proc-macro)
        ├── proc-macro2 v1.0.89
        │   └── unicode-ident v1.0.13
        ├── quote v1.0.37
        │   └── proc-macro2 v1.0.89 (*)
        └── syn v2.0.87
            ├── proc-macro2 v1.0.89 (*)
            ├── quote v1.0.37 (*)
            └── unicode-ident v1.0.13
[dev-dependencies]
└── tokio v1.41.1 (*)
```

After:
```
tokio-eventfd v0.2.1 (/home/chadaustin/projects/tokio-eventfd)
├── libc v0.2.164
└── tokio v1.41.1
    ├── bytes v1.8.0
    ├── libc v0.2.164
    ├── mio v1.0.2
    │   └── libc v0.2.164
    ├── pin-project-lite v0.2.15
    ├── socket2 v0.5.7
    │   └── libc v0.2.164
    └── tokio-macros v2.4.0 (proc-macro)
        ├── proc-macro2 v1.0.89
        │   └── unicode-ident v1.0.13
        ├── quote v1.0.37
        │   └── proc-macro2 v1.0.89 (*)
        └── syn v2.0.87
            ├── proc-macro2 v1.0.89 (*)
            ├── quote v1.0.37 (*)
            └── unicode-ident v1.0.13
[dev-dependencies]
└── tokio v1.41.1 (*)
```

Fixes #3